### PR TITLE
chore(package): update cli-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "body-parser": "1.14.1",
     "browserify": "12.0.1",
     "browserify-shim": "3.8.11",
-    "cli-release": "1.0.3",
+    "cli-release": "1.0.4",
     "cookie-parser": "1.4.0",
     "eslint": "1.10.3",
     "eslint-config-cycle": "3.1.0",


### PR DESCRIPTION
Update cli-release to v1.0.4 for support of npm 3.x

Closes motorcyclejs/motorcycle#8
