### PR TITLE
chore(package): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "Standard HTTP driver for Motorcycle.js",
   "main": "lib/index.js",
   "peerDependencies": {
-    "@motorcycle/core": "*",
-    "@most/hold": "*"
+    "@motorcycle/core": "0.2.0"
   },
   "dependencies": {
+    "@most/hold": "0.2.0",
     "superagent": "1.5.0"
   },
   "devDependencies": {
-    "@most/hold": "0.1.1",
-    "@motorcycle/core": "0.1.7",
+    "@most/hold": "0.2.0",
+    "@motorcycle/core": "0.2.0",
     "babel-cli": "6.3.13",
     "babel-core": "6.3.13",
     "babel-eslint": "4.1.6",


### PR DESCRIPTION
Update devDependencies on @motorcycle/core and @most/hold to 0.2.0
Move @most/hold to dependencies section and lock at 0.2.0
Lock @motorcycle/core peerDependency to 0.2.0

References motorcyclejs/motorcycle#19
